### PR TITLE
feat: add docker setup with mongo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+dist
+.git
+.idea
+
+.env
+

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+BOT_TOKEN=your-telegram-bot-token
+MONGO_URI=mongodb://root:example@mongo:27017/tg-game?authSource=admin
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+npm-debug.log
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Runtime stage
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+RUN npm install --only=production
+COPY --from=builder /app/dist ./dist
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    container_name: tg-bot-buttons
+    restart: unless-stopped
+    env_file:
+      - .env
+    depends_on:
+      - mongo
+  mongo:
+    image: mongo:7
+    container_name: mongodb
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+volumes:
+  mongo-data:
+

--- a/readme.md
+++ b/readme.md
@@ -28,3 +28,12 @@ Build and run:
 npm run build
 npm start
 ```
+
+## Docker
+
+Run the bot and MongoDB with Docker Compose:
+```
+cp .env.example .env
+docker-compose up --build
+```
+


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose for running the bot with MongoDB
- provide env example and ignore files
- document Docker usage

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm test` *(fails: Cannot find module 'telegraf' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68af75a53b7883229f1be431fcc5320b