### PR TITLE
Refactor admin flow and improve player listings

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,0 +1,154 @@
+import random
+from datetime import datetime
+
+from telegram import Update
+from telegram.ext import CallbackQueryHandler, ContextTypes
+
+from storage import users, games, awaiting_admin_codes, ADMIN_IDS, START_KEYBOARD
+from utils import get_game, is_admin, send_menu, get_name
+
+
+async def add_codes(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    await query.message.delete()
+    tg_id = query.from_user.id
+    game = get_game()
+    if not is_admin(game, tg_id):
+        return
+    awaiting_admin_codes.add(tg_id)
+    await context.bot.send_message(tg_id, "Отправьте коды через пробел.")
+
+
+async def player_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    await query.message.delete()
+    tg_id = query.from_user.id
+    game = get_game()
+    if not is_admin(game, tg_id):
+        return
+    players = list(users.find({"telegram_id": {"$nin": game.get("admin_ids", [])}}))
+    if players:
+        text = "Подключенные игроки:\n" + "\n".join(get_name(p) for p in players)
+    else:
+        text = "Нет подключенных игроков."
+    await context.bot.send_message(tg_id, text)
+    user = users.find_one({"telegram_id": tg_id})
+    await send_menu(tg_id, user, game, context)
+
+
+async def start_game(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    await query.message.delete()
+    tg_id = query.from_user.id
+    game = get_game()
+    if not is_admin(game, tg_id):
+        return
+    if game.get("status") != "waiting":
+        await context.bot.send_message(tg_id, "Игра уже началась.")
+        user = users.find_one({"telegram_id": tg_id})
+        await send_menu(tg_id, user, game, context)
+        return
+    players = list(
+        users.find({"telegram_id": {"$nin": game.get("admin_ids", [])}, "code": None})
+    )
+    codes = game.get("codes", [])
+    if len(codes) < len(players):
+        await context.bot.send_message(tg_id, "Недостаточно кодов для всех игроков.")
+        user = users.find_one({"telegram_id": tg_id})
+        await send_menu(tg_id, user, game, context)
+        return
+    random.shuffle(codes)
+    assigned = codes[: len(players)]
+    for player, code in zip(players, assigned):
+        users.update_one({"_id": player["_id"]}, {"$set": {"code": code}})
+    remaining = codes[len(players) :]
+    games.update_one(
+        {"_id": game["_id"]},
+        {
+            "$set": {
+                "status": "running",
+                "started_at": datetime.utcnow(),
+                "ended_at": None,
+                "codes": remaining,
+            }
+        },
+    )
+    users.update_many({}, {"$set": {"discovered_opponent_ids": []}})
+    for u in users.find({}):
+        await context.bot.send_message(
+            u["telegram_id"],
+            "Игра началась! Нажмите \"Начать\", чтобы открыть меню.",
+            reply_markup=START_KEYBOARD,
+        )
+    user = users.find_one({"telegram_id": tg_id})
+    await send_menu(tg_id, user, get_game(), context)
+
+
+async def end_game(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    await query.message.delete()
+    tg_id = query.from_user.id
+    game = get_game()
+    if not is_admin(game, tg_id):
+        return
+    if game.get("status") != "running":
+        await context.bot.send_message(tg_id, "Игра не запущена.")
+        user = users.find_one({"telegram_id": tg_id})
+        await send_menu(tg_id, user, game, context)
+        return
+    games.update_one(
+        {"_id": game["_id"]},
+        {"$set": {"status": "ended", "ended_at": datetime.utcnow()}},
+    )
+    await context.bot.send_message(tg_id, "Игра завершена.")
+    user = users.find_one({"telegram_id": tg_id})
+    await send_menu(tg_id, user, get_game(), context)
+
+
+async def reset_game(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    await query.message.delete()
+    tg_id = query.from_user.id
+    game = get_game()
+    if not is_admin(game, tg_id):
+        return
+    games.update_one(
+        {"_id": game["_id"]},
+        {
+            "$set": {
+                "status": "waiting",
+                "started_at": None,
+                "ended_at": None,
+                "codes": [],
+            }
+        },
+    )
+    users.delete_many({"telegram_id": {"$nin": ADMIN_IDS}})
+    users.update_many(
+        {"telegram_id": {"$in": ADMIN_IDS}},
+        {
+            "$set": {
+                "alive": True,
+                "kicked_by": None,
+                "discovered_opponent_ids": [],
+                "code": None,
+                "isAdmin": True,
+            }
+        },
+    )
+    await context.bot.send_message(tg_id, "Игра сброшена.")
+    user = users.find_one({"telegram_id": tg_id})
+    await send_menu(tg_id, user, get_game(), context)
+
+
+def register_admin_handlers(application):
+    application.add_handler(CallbackQueryHandler(start_game, pattern="^start_game$"))
+    application.add_handler(CallbackQueryHandler(end_game, pattern="^end_game$"))
+    application.add_handler(CallbackQueryHandler(reset_game, pattern="^reset_game$"))
+    application.add_handler(CallbackQueryHandler(add_codes, pattern="^add_codes$"))
+    application.add_handler(CallbackQueryHandler(player_list, pattern="^player_list$"))

--- a/storage.py
+++ b/storage.py
@@ -1,0 +1,30 @@
+import os
+from typing import Dict, Set
+
+from dotenv import load_dotenv
+from pymongo import MongoClient
+from telegram import ReplyKeyboardMarkup, KeyboardButton
+
+load_dotenv()
+
+BOT_TOKEN = os.getenv("BOT_TOKEN")
+MONGO_URI = os.getenv("MONGO_URI")
+ADMIN_IDS = [int(x) for x in os.getenv("ADMIN_IDS", "").split(",") if x]
+
+if not BOT_TOKEN:
+    raise ValueError("BOT_TOKEN not provided")
+
+client = MongoClient(MONGO_URI)
+db = client["tg-game"]
+users = db["users"]
+games = db["games"]
+
+# Ensure each Telegram user ID is stored only once
+users.create_index("telegram_id", unique=True)
+
+awaiting_code: Set[int] = set()
+pending_kick: Dict[int, str] = {}
+awaiting_admin_codes: Set[int] = set()
+
+# Reply keyboard with a physical "Начать" button so players can always return to the menu
+START_KEYBOARD = ReplyKeyboardMarkup([[KeyboardButton("Начать")]], resize_keyboard=True)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,75 @@
+from typing import Dict
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import ContextTypes
+
+from storage import games, ADMIN_IDS, START_KEYBOARD
+
+
+def get_name(user: Dict) -> str:
+    return "@" + (user.get("username") or user.get("first_name") or "user")
+
+
+def get_game() -> Dict:
+    game = games.find_one()
+    if not game:
+        game = {"status": "waiting", "admin_ids": ADMIN_IDS, "codes": []}
+        games.insert_one(game)
+    return game
+
+
+def is_admin(game: Dict, tg_id: int) -> bool:
+    return tg_id in game.get("admin_ids", [])
+
+
+async def send_menu(
+    chat_id: int, user: Dict, game: Dict, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    await context.bot.send_message(
+        chat_id,
+        "Для возвращения в меню используйте кнопку \"Начать\"",
+        reply_markup=START_KEYBOARD,
+    )
+    if game.get("status") != "running" and not is_admin(game, chat_id):
+        await context.bot.send_message(chat_id, "Игра еще не началась.")
+        return
+    buttons = []
+    if game.get("status") == "running" and not is_admin(game, chat_id):
+        buttons.extend(
+            [
+                [InlineKeyboardButton("Ввести код", callback_data="menu_code")],
+                [InlineKeyboardButton("Список противников", callback_data="menu_list")],
+            ]
+        )
+    if is_admin(game, chat_id):
+        admin_buttons = []
+        if game.get("status") == "waiting":
+            admin_buttons.append(
+                InlineKeyboardButton("Начать игру", callback_data="start_game")
+            )
+            admin_buttons.append(
+                InlineKeyboardButton("Добавить коды", callback_data="add_codes")
+            )
+        elif game.get("status") == "running":
+            admin_buttons.append(
+                InlineKeyboardButton("Закончить игру", callback_data="end_game")
+            )
+            admin_buttons.append(
+                InlineKeyboardButton("Сбросить игру", callback_data="reset_game")
+            )
+            admin_buttons.append(
+                InlineKeyboardButton("Добавить коды", callback_data="add_codes")
+            )
+        else:
+            admin_buttons.append(
+                InlineKeyboardButton("Сбросить игру", callback_data="reset_game")
+            )
+        admin_buttons.append(
+            InlineKeyboardButton("Игроки", callback_data="player_list")
+        )
+        if admin_buttons:
+            buttons.append(admin_buttons)
+    if buttons:
+        await context.bot.send_message(
+            chat_id, "Выберите действие:", reply_markup=InlineKeyboardMarkup(buttons)
+        )


### PR DESCRIPTION
## Summary
- hide code entry and opponent list buttons for admins
- show connected player names via new "Игроки" admin button
- split bot into modules and stop notifying opponents when their code is guessed

## Testing
- `python -m py_compile storage.py utils.py admin.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0af1ed6a48322836acef1044849da