### PR TITLE
Add emoji pair management and player numbering

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -18,6 +18,7 @@ client = MongoClient(MONGO_URI)
 db = client["tg-game"]
 users = db["users"]
 games = db["games"]
+emoji_pairs = db["emoji_pairs"]
 
 # Ensure each Telegram user ID is stored only once
 users.create_index("telegram_id", unique=True)
@@ -25,6 +26,13 @@ users.create_index("telegram_id", unique=True)
 awaiting_code: Set[int] = set()
 pending_kick: Dict[int, str] = {}
 awaiting_admin_codes: Set[int] = set()
+
+CIRCLE_EMOJIS = ["🔴", "🟠", "🟡", "🟢", "🔵", "🟣", "🟤", "⚫", "⚪"]
+SQUARE_NUMBERS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"]
+
+if emoji_pairs.count_documents({}) == 0:
+    for circle, square in zip(CIRCLE_EMOJIS, SQUARE_NUMBERS):
+        emoji_pairs.insert_one({"circle": circle, "square": square})
 
 # Reply keyboard with a physical "Начать" button so players can always return to the menu
 START_KEYBOARD = ReplyKeyboardMarkup([[KeyboardButton("Начать")]], resize_keyboard=True)

--- a/utils.py
+++ b/utils.py
@@ -3,7 +3,7 @@ from typing import Dict
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
-from storage import games, ADMIN_IDS, START_KEYBOARD
+from storage import games, ADMIN_IDS, START_KEYBOARD, SQUARE_NUMBERS
 
 
 def get_name(user: Dict) -> str:
@@ -20,6 +20,12 @@ def get_game() -> Dict:
 
 def is_admin(game: Dict, tg_id: int) -> bool:
     return tg_id in game.get("admin_ids", [])
+
+
+def number_to_square(n) -> str:
+    if isinstance(n, int) and 1 <= n <= len(SQUARE_NUMBERS):
+        return SQUARE_NUMBERS[n - 1]
+    return ""
 
 
 async def send_menu(
@@ -62,6 +68,12 @@ async def send_menu(
         )
         if admin_buttons:
             buttons.append(admin_buttons)
+        buttons.append(
+            [
+                InlineKeyboardButton("Пары", callback_data="show_pairs"),
+                InlineKeyboardButton("Перемешать пары", callback_data="shuffle_pairs"),
+            ]
+        )
     if buttons:
         await context.bot.send_message(
             chat_id, "Выберите действие:", reply_markup=InlineKeyboardMarkup(buttons)


### PR DESCRIPTION
## Summary
- Track colored circle–number square pairs in a dedicated DB collection
- Allow admins to view and randomly shuffle the emoji pairs from the menu
- Assign sequential number emojis to players on join and limit game to nine players

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b0b4f913fc8322b96a9354f57b7878