### PR TITLE
Refactor emoji pair mapping and update admin UI

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,7 +18,14 @@ from storage import (
     awaiting_admin_codes,
     START_KEYBOARD,
 )
-from utils import get_name, get_game, is_admin, send_menu, number_to_square
+from utils import (
+    get_name,
+    get_game,
+    is_admin,
+    send_menu,
+    number_to_square,
+    number_to_circle,
+)
 from admin import register_admin_handlers
 
 
@@ -60,10 +67,11 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         user = users.find_one({"telegram_id": tg_id})
         if not is_admin_flag:
             square = number_to_square(number)
+            circle = number_to_circle(number)
             for admin_id in game.get("admin_ids", []):
                 await context.bot.send_message(
                     admin_id,
-                    f"Подключился игрок {get_name(user)} {square}",
+                    f"Подключился игрок {get_name(user)} {square}{circle}",
                 )
     if not user.get("alive", True):
         kicker = users.find_one({"_id": user.get("kicked_by")})

--- a/storage.py
+++ b/storage.py
@@ -30,9 +30,10 @@ awaiting_admin_codes: Set[int] = set()
 CIRCLE_EMOJIS = ["🔴", "🟠", "🟡", "🟢", "🔵", "🟣", "🟤", "⚫", "⚪"]
 SQUARE_NUMBERS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"]
 
+# Store mapping between number (1-9) and circle color
 if emoji_pairs.count_documents({}) == 0:
-    for circle, square in zip(CIRCLE_EMOJIS, SQUARE_NUMBERS):
-        emoji_pairs.insert_one({"circle": circle, "square": square})
+    for i, circle in enumerate(CIRCLE_EMOJIS, start=1):
+        emoji_pairs.insert_one({"number": i, "circle": circle})
 
 # Reply keyboard with a physical "Начать" button so players can always return to the menu
 START_KEYBOARD = ReplyKeyboardMarkup([[KeyboardButton("Начать")]], resize_keyboard=True)


### PR DESCRIPTION
## Summary
- Store emoji pairs as number-color mappings and shuffle only colors
- Notify admins with player number and color on join
- Show detailed player list with codes and status
- Limit admin menu during games to end and list buttons

## Testing
- `python -m py_compile admin.py bot.py storage.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0b8de64d88322a88726e5230e7a6b