### PR TITLE
Refine menus and block reuse codes

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,7 +1,7 @@
 import random
 from datetime import datetime
 
-from telegram import Update
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import CallbackQueryHandler, ContextTypes
 
 from storage import (
@@ -70,9 +70,13 @@ async def show_pairs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     text = "Пары:\n" + "\n".join(
         f"{number_to_square(p['number'])} - {p['circle']}" for p in pairs
     )
-    await context.bot.send_message(tg_id, text)
-    user = users.find_one({"telegram_id": tg_id})
-    await send_menu(tg_id, user, game, context)
+    buttons = [
+        [InlineKeyboardButton("Перемешать пары", callback_data="shuffle_pairs")],
+        [InlineKeyboardButton("Назад", callback_data="back_to_menu")],
+    ]
+    await context.bot.send_message(
+        tg_id, text, reply_markup=InlineKeyboardMarkup(buttons)
+    )
 
 
 async def shuffle_pairs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -93,9 +97,13 @@ async def shuffle_pairs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     text = "Пары перемешаны:\n" + "\n".join(
         f"{number_to_square(p['number'])} - {p['circle']}" for p in pairs
     )
-    await context.bot.send_message(tg_id, text)
-    user = users.find_one({"telegram_id": tg_id})
-    await send_menu(tg_id, user, game, context)
+    buttons = [
+        [InlineKeyboardButton("Перемешать пары", callback_data="shuffle_pairs")],
+        [InlineKeyboardButton("Назад", callback_data="back_to_menu")],
+    ]
+    await context.bot.send_message(
+        tg_id, text, reply_markup=InlineKeyboardMarkup(buttons)
+    )
 
 
 async def start_game(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -136,7 +144,7 @@ async def start_game(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
             }
         },
     )
-    users.update_many({}, {"$set": {"discovered_opponent_ids": []}})
+    users.update_many({}, {"$set": {"discovered_opponent_ids": [], "code_used": False}})
     for u in users.find({}):
         await context.bot.send_message(
             u["telegram_id"],
@@ -187,6 +195,7 @@ async def end_game(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 "discovered_opponent_ids": [],
                 "code": None,
                 "isAdmin": True,
+                "code_used": False,
             }
         },
     )

--- a/utils.py
+++ b/utils.py
@@ -47,7 +47,7 @@ async def send_menu(
         buttons.extend(
             [
                 [InlineKeyboardButton("Ввести код", callback_data="menu_code")],
-                [InlineKeyboardButton("Список противников", callback_data="menu_list")],
+                [InlineKeyboardButton("Доступные кнопки", callback_data="menu_list")],
             ]
         )
     if is_admin(game, chat_id):
@@ -62,12 +62,7 @@ async def send_menu(
                 [InlineKeyboardButton("Игроки", callback_data="player_list")]
             )
             buttons.append(
-                [
-                    InlineKeyboardButton("Пары", callback_data="show_pairs"),
-                    InlineKeyboardButton(
-                        "Перемешать пары", callback_data="shuffle_pairs"
-                    ),
-                ]
+                [InlineKeyboardButton("Пары", callback_data="show_pairs")]
             )
         elif game.get("status") == "running":
             buttons.append(


### PR DESCRIPTION
## Summary
- Move pair shuffling into dedicated "Pairs" submenu with back navigation
- Rename player opponent list to color-coded "Available buttons" with back button
- Update game text to "block player" and ensure codes are single-use without reciprocal discovery

## Testing
- `python -m py_compile admin.py bot.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0bddbc16c83229c56c91c1d985694