### PR TITLE
feat: allow players to self-exit and broadcast button color

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Set
+from typing import Set
 
 from dotenv import load_dotenv
 from pymongo import MongoClient
@@ -24,7 +24,6 @@ emoji_pairs = db["emoji_pairs"]
 users.create_index("telegram_id", unique=True)
 
 awaiting_code: Set[int] = set()
-pending_kick: Dict[int, str] = {}
 awaiting_admin_codes: Set[int] = set()
 
 CIRCLE_EMOJIS = ["🔴", "🟠", "🟡", "🟢", "🔵", "🟣", "🟤", "⚫", "⚪"]
@@ -33,7 +32,9 @@ SQUARE_NUMBERS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️�
 # Store mapping between number (1-9) and circle color
 if emoji_pairs.count_documents({}) == 0:
     for i, circle in enumerate(CIRCLE_EMOJIS, start=1):
-        emoji_pairs.insert_one({"number": i, "circle": circle})
+        emoji_pairs.insert_one(
+            {"number": i, "circle": circle, "taken": False, "blocked": False}
+        )
 
 # Reply keyboard with a physical "Начать" button so players can always return to the menu
 START_KEYBOARD = ReplyKeyboardMarkup([[KeyboardButton("Начать")]], resize_keyboard=True)


### PR DESCRIPTION
## Summary
- show color when a player enters a code and allow self-discovery
- notify others when a button is pressed and mark buttons taken/blocked
- track button pair status with taken and blocked flags

## Testing
- `python -m py_compile bot.py admin.py storage.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0c287b3708322add9ce870fc0d68d