### PR TITLE
Add block confirmations and admin button overview

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -73,6 +73,9 @@ async def send_menu(
                     ),
                 ]
             )
+            buttons.append(
+                [InlineKeyboardButton("Кнопки", callback_data="button_status")]
+            )
     if buttons:
         await context.bot.send_message(
             chat_id, "Выберите действие:", reply_markup=InlineKeyboardMarkup(buttons)


### PR DESCRIPTION
## Summary
- Add confirmation dialog before blocking a player and allow cancel
- Notify everyone when a player leaves using only number emoji
- Introduce admin menu button to show each button's status

## Testing
- `python -m py_compile bot.py admin.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0c79e266c832292d3305a0ed53be4