### PR TITLE
Fix UnboundLocalError by renaming local buttons variables

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -89,12 +89,12 @@ async def show_pairs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         f"{'заблокирована' if p.get('blocked') else ('занята' if p.get('player_id') else 'свободна')}"
         for p in pairs
     )
-    buttons = [
+    keyboard = [
         [InlineKeyboardButton("Перемешать пары", callback_data="shuffle_pairs")],
         [InlineKeyboardButton("Назад", callback_data="back_to_menu")],
     ]
     await context.bot.send_message(
-        tg_id, text, reply_markup=InlineKeyboardMarkup(buttons)
+        tg_id, text, reply_markup=InlineKeyboardMarkup(keyboard)
     )
 
 
@@ -136,9 +136,9 @@ async def button_status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         else:
             status.append("В игре ⛳")
         lines.append(f"Особая {s.get('emoji', '🔀')} - {', '.join(status)}")
-    buttons = [[InlineKeyboardButton("Назад", callback_data="back_to_menu")]]
+    keyboard = [[InlineKeyboardButton("Назад", callback_data="back_to_menu")]]
     await context.bot.send_message(
-        tg_id, "\n".join(lines), reply_markup=InlineKeyboardMarkup(buttons)
+        tg_id, "\n".join(lines), reply_markup=InlineKeyboardMarkup(keyboard)
     )
 
 
@@ -159,12 +159,12 @@ async def shuffle_pairs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     text = "Пары перемешаны:\n" + "\n".join(
         f"{number_to_square(p['number'])} - {p['circle']}" for p in pairs
     )
-    buttons = [
+    keyboard = [
         [InlineKeyboardButton("Перемешать пары", callback_data="shuffle_pairs")],
         [InlineKeyboardButton("Назад", callback_data="back_to_menu")],
     ]
     await context.bot.send_message(
-        tg_id, text, reply_markup=InlineKeyboardMarkup(buttons)
+        tg_id, text, reply_markup=InlineKeyboardMarkup(keyboard)
     )
 
 

--- a/bot.py
+++ b/bot.py
@@ -309,7 +309,7 @@ async def confirm_kick(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if not opponent:
         return
     circle = number_to_circle(opponent.get("number"))
-    buttons = [
+    keyboard = [
         [
             InlineKeyboardButton("Да", callback_data=f"kick:{opponent_id}"),
             InlineKeyboardButton("Нет", callback_data="cancel_kick"),
@@ -318,7 +318,7 @@ async def confirm_kick(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await context.bot.send_message(
         query.from_user.id,
         f"Нажать {circle} кнопку?",
-        reply_markup=InlineKeyboardMarkup(buttons),
+        reply_markup=InlineKeyboardMarkup(keyboard),
     )
 
 

--- a/utils.py
+++ b/utils.py
@@ -42,9 +42,9 @@ async def send_menu(
     if game.get("status") != "running" and not is_admin(game, chat_id):
         await context.bot.send_message(chat_id, "Игра еще не началась.")
         return
-    buttons = []
+    keyboard = []
     if game.get("status") == "running" and not is_admin(game, chat_id):
-        buttons.extend(
+        keyboard.extend(
             [
                 [InlineKeyboardButton("Ввести код", callback_data="menu_code")],
                 [InlineKeyboardButton("Доступные кнопки", callback_data="menu_list")],
@@ -52,19 +52,19 @@ async def send_menu(
         )
     if is_admin(game, chat_id):
         if game.get("status") == "waiting":
-            buttons.append(
+            keyboard.append(
                 [
                     InlineKeyboardButton("Начать игру", callback_data="start_game"),
                     InlineKeyboardButton("Добавить коды", callback_data="add_codes"),
                 ]
             )
-            buttons.append(
+            keyboard.append(
                 [InlineKeyboardButton("Игроки", callback_data="player_list")]
             )
-            buttons.append(
+            keyboard.append(
                 [InlineKeyboardButton("Пары", callback_data="show_pairs")]
             )
-            buttons.append(
+            keyboard.append(
                 [
                     InlineKeyboardButton(
                         "Добавить особую кнопку", callback_data="add_special"
@@ -72,7 +72,7 @@ async def send_menu(
                 ]
             )
         elif game.get("status") == "running":
-            buttons.append(
+            keyboard.append(
                 [
                     InlineKeyboardButton("Завершить игру", callback_data="end_game"),
                     InlineKeyboardButton(
@@ -80,10 +80,10 @@ async def send_menu(
                     ),
                 ]
             )
-            buttons.append(
+            keyboard.append(
                 [InlineKeyboardButton("Кнопки", callback_data="button_status")]
             )
-    if buttons:
+    if keyboard:
         await context.bot.send_message(
-            chat_id, "Выберите действие:", reply_markup=InlineKeyboardMarkup(buttons)
+            chat_id, "Выберите действие:", reply_markup=InlineKeyboardMarkup(keyboard)
         )


### PR DESCRIPTION
## Summary
- Rename local `buttons` lists to `keyboard` in admin commands to avoid shadowing the global buttons collection
- Adjust confirm kick dialog and menu builder to use `keyboard`

## Testing
- `python -m py_compile admin.py bot.py utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e213334c8322aa987c1159b00f08